### PR TITLE
Use ordered map

### DIFF
--- a/include/reef_moonshiners/ui/main_window.hpp
+++ b/include/reef_moonshiners/ui/main_window.hpp
@@ -109,14 +109,14 @@ private:
 
   QListWidget * m_p_list_widget = nullptr;
 
-  std::unordered_map<std::unique_ptr<reef_moonshiners::DailyElement>, ElementDisplay *> m_elements;
-  std::unordered_map<std::unique_ptr<reef_moonshiners::DropperElement>,
+  std::map<std::unique_ptr<reef_moonshiners::DailyElement>, ElementDisplay *> m_elements;
+  std::map<std::unique_ptr<reef_moonshiners::DropperElement>,
     ElementDisplay *> m_dropper_elements;
   reef_moonshiners::Iodine * m_p_iodine_element = nullptr;
   reef_moonshiners::Vanadium * m_p_vanadium_element = nullptr;
   std::unique_ptr<reef_moonshiners::Rubidium> m_p_rubidium_element = nullptr;
   ElementDisplay * m_p_rubidium_display = nullptr;
-  std::unordered_map<std::unique_ptr<reef_moonshiners::CorrectionElement>,
+  std::map<std::unique_ptr<reef_moonshiners::CorrectionElement>,
     ElementDisplay *> m_correction_elements;
 };
 

--- a/test/test_corrections.cpp
+++ b/test/test_corrections.cpp
@@ -153,7 +153,7 @@ TEST(TestCorrections, test_barium_sponge)
   EXPECT_DOUBLE_EQ(element.get_concentration_estimate(now), 30);
 }
 
-TEST(TestDailies, test_ostream)
+TEST(TestCorrections, test_ostream)
 {
   const std::chrono::year_month_day now{std::chrono::floor<std::chrono::days>(
       std::chrono::system_clock::now())};
@@ -165,6 +165,8 @@ TEST(TestDailies, test_ostream)
 
   fs::path out = fs::temp_directory_path() / "out";
   std::ofstream out_file{out, std::ios::binary};
+  static constexpr size_t out_version = 3;
+  reef_moonshiners::binary_out(out_file, out_version);
   out_file << molybdenum_out << fluorine_out;
   out_file.close();
 
@@ -172,7 +174,11 @@ TEST(TestDailies, test_ostream)
   reef_moonshiners::Molybdenum molybdenum_in;
   reef_moonshiners::Fluorine fluorine_in;
   std::ifstream in_file{out, std::ios::binary};
-  in_file >> molybdenum_in >> fluorine_in;
+  size_t input_version;
+  reef_moonshiners::binary_in(in_file, input_version);
+  EXPECT_EQ(input_version, out_version);
+  reef_moonshiners::ElementBase::set_load_version(input_version);
+  in_file  >> molybdenum_in >> fluorine_in;
   EXPECT_EQ(molybdenum_in.get_name(), "Molybdenum"s);
   EXPECT_EQ(molybdenum_in.get_dose(now), molybdenum_out.get_dose(now));
   EXPECT_EQ(molybdenum_in.get_max_daily_dosage(), molybdenum_out.get_max_daily_dosage());

--- a/test/test_dailies.cpp
+++ b/test/test_dailies.cpp
@@ -84,6 +84,8 @@ TEST(TestDailies, test_ostream)
 
   fs::path out = fs::temp_directory_path() / "out";
   std::ofstream out_file{out, std::ios::binary};
+  static constexpr size_t out_version = 3;
+  reef_moonshiners::binary_out(out_file, out_version);
   out_file << selenium_out << iron_out;
   out_file.close();
 
@@ -91,6 +93,10 @@ TEST(TestDailies, test_ostream)
   reef_moonshiners::Selenium selenium_in;
   reef_moonshiners::Iron iron_in;
   std::ifstream in_file{out, std::ios::binary};
+  size_t input_version;
+  reef_moonshiners::binary_in(in_file, input_version);
+  EXPECT_EQ(input_version, out_version);
+  reef_moonshiners::ElementBase::set_load_version(input_version);
   in_file >> selenium_in >> iron_in;
   EXPECT_EQ(selenium_in.get_name(), "Selenium"s);
   EXPECT_EQ(selenium_in.get_multiplier(), selenium_out.get_multiplier());


### PR DESCRIPTION
I think some consistency issues are happening on android and windows because of the unordered map being used. This patch switches to a `std::map` (ordered) instead, hopefully fixing some inconsistencies.